### PR TITLE
Dont reset the model when testing

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,3 +1,4 @@
 packages:
   - amulet
 tests: 10-deploy.py
+reset: false


### PR DESCRIPTION
To enable tests to run quickly, we should avoid resetting the
environment.
