### PR TITLE
bring up-to-date with canonical-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,123 +1,404 @@
-# Core Kubernetes Bundle
+# Kubernetes Core Bundle
 
-This is a Juju bundle that creates a basic Kubernetes cluster. This bundle 
-deploys the minimum number of resources needed to get started using Google's 
-container orchestrator, Kubernetes.
+![](https://img.shields.io/badge/release-beta-yellow.svg) ![](https://img.shields.io/badge/kubernetes-1.4.0-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 
-Kubernetes is an open-source platform for automating deployment, operations,
-and scaling of containerized applications across clusters of hosts.
+This is a minimal Kubernetes cluster comprised of the following components and features:
 
-It groups containers that make up an application into logical units for easy
-management and discovery. You can scale up the individual pieces to create a 
-larger cluster.
+- Kubernetes (automated deployment, operations, and scaling)
+     - Two node Kubernetes cluster with one master node and one worker node.
+     - TLS used for communication between nodes for security.
+     - Flannel Software Defined Network (SDN) plugin
+     - A load balancer for HA kubernetes-master (Experimental)
+     - Optional Ingress Controller and Dashboard (on worker/master respectively)
+- EasyRSA
+     - Performs the role of a certificate authority serving self signed certificates
+       to the requesting units of the cluster.
+- Etcd (distributed key value store)
+     - One node for basic functionality.
 
-## Usage
+# Usage
 
-To deploy a Kubernetes cluster it is one Juju command:
+This bundle is for small deployments for testing and development. For
+multi-node deployments, use the larger
+[canonical-kubernetes](http://jujucharms.com/canonical-kubernetes) bundle.
+
+## Proxy configuration
+
+If you are operating behind a proxy (i.e., your charms are running in a
+limited-egress environment and can not reach IP addresses external to their
+network), you will need to configure your model appropriately before deploying
+the Kubernetes bundle.
+
+First, configure your model's `http-proxy` and `https-proxy` settings with your
+proxy (here we use `squid.internal:3128` as an example):
+
+```sh
+$ juju model-config http-proxy=http://squid.internal:3128 https-proxy=https://squid.internal:3128
+```
+
+Because services often need to reach machines on their own network (including
+themselves), you will also need to add `localhost` to the `no-proxy` model
+configuration setting, along with any internal subnets you're using. The
+following example includes two subnets:
+
+```sh
+$ juju model-config no-proxy=localhost,10.5.5.0/24,10.246.64.0/21
+```
+
+After deploying the bundle, you need to configure the `kubernetes-worker` charm
+to use your proxy:
+
+```sh
+$ juju config kubernetes-worker http_proxy=http://squid.internal:3128 https_proxy=https://squid.internal:3128
+```
+
+## Deploy the bundle
 
 ```
 juju deploy kubernetes-core
 ```
 
-Juju deployed two units of the kubernetes charm, three units of etcd and 
-related them to form a Kubernetes cluster. One of the kubenetes units is the
-master and the other is a worker. To determine which unit is the master use the
-`juju status` command.
+> Note: If you're operating behind a proxy, remember to set the `kubernetes-worker`
+proxy configuration options as described in the Proxy configuration section
+above.
 
-### Using kubectl
+This bundle exposes the kubeapi-load-balancer and kubernetes-worker charms by
+default. This means those charms are accessible through their public addresses.
 
-After the cluster is deployed download the `kubectl` command line tool and
-the configuration from the master unit. For your convenience, the master unit
-created a package with the certificate, key and configuration to securely
-communicate with this Kubernetes cluster. If the master unit changes, say you
-deploy a new cluster you will need to download the new package as the 
-information has changed.
+If you would like to remove external access, unexpose the applications:
 
 ```
-juju scp kubernetes/<leader-unit-number>:kubectl_package.tar.gz .
-tar zxf kubectl_package.tar.gz
-./kubectl --kubeconfig ./kubeconfig get pods
+juju unexpose kubeapi-load-balancer
+juju unexpose kubernetes-worker
 ```
 
-You should now have the `kubectl` command and configuration for the cluster
-that was just created, you can now check the state of the cluster:
+To get the status of the deployment, run `juju status`. For a constant update,
+this can be used with `watch`.
 
 ```
-./kubectl --kubeconfig ./kubeconfig cluster-info
+watch -c juju status --color
 ```
 
-Create pods and services on the Kubernetes cluster by using resource 
-definitions on your host system:
+### Alternate deployment methods
+
+
+
+#### Usage with your own binaries
+
+In order to support restricted-network deployments, the charms in this bundle
+support
+[juju resources](https://jujucharms.com/docs/2.0/developer-resources#managing-resources).
+
+This allows you to `juju attach` the resources built for the architecture of
+your cloud.
 
 ```
-./kubectl --kubeconfig ./kubeconfig create -f example.yml
+juju attach kubernetes-master kubernetes=~/path/to/kubernetes-master.tar.gz
+```
 
+#### Interactive deployment using Conjure-up
+
+`conjure-up` is an interactive, terminal UI deployment tool for Juju bundles.
+After installing conjure-up, you can deploy the kubernetes-core bundle and tweak config values with one command:
+
+```
+sudo apt install conjure-up
+conjure-up kubernetes-core
+```
+
+Refer to the
+[conjure-up documentation](http://conjure-up.io) to learn more.
+
+## Interacting with the Kubernetes cluster
+
+After the cluster is deployed you may assume control over the Kubernetes cluster
+from any kubernetes-master, or kubernetes-worker node.
+
+To download the credentials and client application to your local workstation:
+
+Create the kubectl config directory.
+
+```
+mkdir -p ~/.kube
+```
+
+Copy the kubeconfig to the default location.
+
+```
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+Fetch a binary for the architecture you have deployed. If your client is a
+different architecture you will need to get the appropriate `kubectl` binary
+through other means.
+
+```
+juju scp kubernetes-master/0:kubectl ./kubectl
+```
+
+Query the cluster.
+
+```
+./kubectl cluster-info
+```
+
+### Accessing the Kubernetes Dashboard
+
+With `kubectl` placed in your `$PATH` and having the config placed, you may
+establish a secure tunnel to your cluster with the following command:
+
+```
+./kubectl proxy
+```
+
+By default, this establishes a proxy running on your local machine and the
+kubernetes-master unit. To reach the Kubernetes dashboard, visit
+`http://localhost:8001/ui`
+
+
+### Control the cluster
+
+kubectl is the command line utility to interact with a Kubernetes cluster.
+
+
+#### Minimal getting started
+
+To check the state of the cluster:
+
+```
+./kubectl cluster-info
+```
+
+List all nodes in the cluster:
+
+```
+./kubectl get nodes
+```
+
+Now you can run pods inside the Kubernetes cluster:
+
+```
+./kubectl create -f example.yaml
 ```
 
 List all pods in the cluster:
 
+
 ```
-./kubectl --kubeconfig ./kubeconfig get pods
+./kubectl get pods
 ```
 
 List all services in the cluster:
 
 ```
-./kubectl --kubeconfig ./kubeconfig get svc
+./kubectl get services
 ```
 
-You should be able to manage the Kubernetes cluster by using the `kubectl` 
-command line tool. Use the 
-[kubectl-cheatsheet](http://kubernetes.io/docs/user-guide/kubectl-cheatsheet/) 
-for more information about the `kubectl` command.
+For expanded information on kubectl beyond what this README provides, please
+see the
+[kubectl overview](http://kubernetes.io/docs/user-guide/kubectl-overview/)
+which contains practical examples and an API reference.
 
-## Scale out Usage
+Additionally if you need to manage multiple clusters, there is more information
+about configuring kubectl with the
+[kubectl config guide](http://kubernetes.io/docs/user-guide/kubectl/kubectl_config/)
 
-Any of the services provided can be scaled out post-deployment. By default
-the pods are automatically be spread throughout the Kubernetes clusters you
-have deployed.
 
-### Scaling Kubernetes Up
+### Using Ingress
 
-To add more Kubernetes nodes to the cluster:
+The kubernetes-worker charm supports deploying an NGINX ingress controller.
+Ingress allows access from the Internet to containers inside the cluster
+running web services.
 
-    juju add-unit kubernetes
+First allow the Internet access to the kubernetes-worker charm with with the
+following Juju command:
+
+```
+juju expose kubernetes-worker
+```
+
+In Kubernetes, workloads are declared using pod, service, and ingress
+definitions. An ingress controller is provided to you by default, deployed into
+the
+[default namespace](http://kubernetes.io/docs/user-guide/namespaces/) of the
+cluster. If one is not available, you may deploy this with:
+
+```
+juju config kubernetes-worker ingress=true
+```
+
+Ingress resources are DNS mappings to your containers, routed through
+[endpoints](http://kubernetes.io/docs/user-guide/services/)
+
+As an example for users unfamiliar with Kubernetes, we packaged an action to
+both deploy an example and clean itself up.
+
+To deploy 5 replicas of the microbot web application inside the Kubernetes
+cluster run the following command:
+
+```
+juju run-action kubernetes-worker/0 microbot replicas=5
+```
+
+This action performs the following steps:
+
+- It creates a deployment titled 'microbots' comprised of 5 replicas defined
+during the run of the action. It also creates a service named 'microbots'
+which binds an 'endpoint', using all 5 of the 'microbots' pods.
+
+- Finally, it will create an ingress resource, which points at a
+[xip.io](https://xip.io) domain to simulate a proper DNS service.
+
+
+#### Running the packaged simulation
+
+
+    $ juju run-action kubernetes-worker/0 microbot replicas=3
+    Action queued with id: db7cc72b-5f35-4a4d-877c-284c4b776eb8
+
+    $ juju show-action-output db7cc72b-5f35-4a4d-877c-284c4b776eb8
+    results:
+      address: microbot.104.198.77.197.xip.io
+    status: completed
+    timing:
+      completed: 2016-09-26 20:42:42 +0000 UTC
+      enqueued: 2016-09-26 20:42:39 +0000 UTC
+      started: 2016-09-26 20:42:41 +0000 UTC
+
+
+At this point, you can inspect the cluster to observe the workload coming online.
+
+#### List the pods
+
+
+    $ kubectl get pods
+    NAME                             READY     STATUS    RESTARTS   AGE
+    default-http-backend-kh1dt       1/1       Running   0          1h
+    microbot-1855935831-58shp        1/1       Running   0          1h
+    microbot-1855935831-9d16f        1/1       Running   0          1h
+    microbot-1855935831-l5rt8        1/1       Running   0          1h
+    nginx-ingress-controller-hv5c2   1/1       Running   0          1h
+
+
+
+#### List the services and endpoints
+
+    $ kubectl get services,endpoints
+    NAME                       CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
+    svc/default-http-backend   10.1.225.82   <none>        80/TCP    1h
+    svc/kubernetes             10.1.0.1      <none>        443/TCP   1h
+    svc/microbot               10.1.44.173   <none>        80/TCP    1h
+    NAME                      ENDPOINTS                               AGE
+    ep/default-http-backend   10.1.68.2:80                            1h
+    ep/kubernetes             172.31.31.139:6443                      1h
+    ep/microbot               10.1.20.3:80,10.1.68.3:80,10.1.7.4:80   1h
+
+
+#### List the ingress resources
+
+    $ kubectl get ingress
+    NAME               HOSTS                          ADDRESS         PORTS     AGE
+    microbot-ingress   microbot.52.38.62.235.xip.io   172.31.26.109   80        1h
+
+
+When all the pods are listed as Running, the endpoint has more than one host
+you are ready to visit the address in the hosts section of the ingress listing.
+
+It is normal to see a 502/503 error during initial application turnup.
+
+As you refresh the page, you will be greeted with a microbot web page, serving
+from one of the microbot replica pods. Refreshing will show you another
+microbot with a different hostname, as the requests are load balanced through
+out the replicas.
+
+#### Clean up microbot
+
+There is also an action to clean up the microbot applications. When you are
+done using the microbot application you can delete them from the pods with
+one Juju action:
+
+```
+juju run-action kubernetes-worker/0 microbot delete=true
+```
+
+If you no longer need Internet access to your workers remember to unexpose the
+kubernetes-worker charm:
+
+```
+juju unexpose kubernetes-worker
+```
+
+To learn more about
+[Kubernetes Ingress](http://kubernetes.io/docs/user-guide/ingress.html)
+and how to really tune the Ingress Controller beyond defaults (such as TLS and
+websocket support) view the
+[nginx-ingress-controller](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx)
+project on github.
+
+
+# Scale out Usage
+
+Any of the applications can be scaled out post-deployment. The charms
+update the status messages with progress, so it is recommended to run.
+
+```
+watch -c juju status --color
+```
+
+### Scaling kubernetes-worker
+
+The kubernetes-worker nodes are the load-bearing units of a Kubernetes cluster.
+
+By default pods are automatically spread throughout the kubernetes-worker units
+that you have deployed.
+
+To add more kubernetes-worker units to the cluster:
+
+```
+juju add-unit kubernetes-worker
+```
 
 or specify machine constraints to create larger nodes:
 
-    juju add-unit kubernetes --constraints "cpu-cores=8 mem=32G"
+```
+juju add-unit kubernetes-worker --constraints "cpu-cores=8 mem=32G"
+```
 
 Refer to the
 [machine constraints documentation](https://jujucharms.com/docs/stable/charms-constraints)
-if you want more information about setting larger constraints.
+for other machine constraints that might be useful for the kubernetes-worker units.
+
 
 ### Scaling Etcd
 
 Etcd is used as a key-value store for the Kubernetes cluster. For reliability
-the cluster defaults to three instances in this bundle.
+the bundle defaults to three instances in this cluster.
 
 For more scalability, we recommend between 3 and 9 etcd nodes. If you want to
-add more nodes with `juju add-unit etcd`. The CoreOS etcd documentation has a
-chart for the [optimal cluster size](https://coreos.com/etcd/docs/latest/admin_guide.html#optimal-cluster-size)
+add more nodes:
+
+```
+juju add-unit etcd
+```
+
+The CoreOS etcd documentation has a chart for the
+[optimal cluster size](https://coreos.com/etcd/docs/latest/admin_guide.html#optimal-cluster-size)
 to determine fault tolerance.
 
 ## Known Limitations and Issues
 
  The following are known issues and limitations with the bundle and charm code:
 
- - This bundle is not supported on LXD because Juju needs to use a LXD profile
-that can run Docker containers.
- - Killing the the Kubernetes leader will result in loss of public key
-infrastructure (PKI).
- - No easy way to address the pods from the outside world.
- - The storage feature with ZFS does not work with trusty at this time because
-the code has to be enhanced to load the zfs module.
+ - kubernetes-master, kubernetes-worker, kubeapi-load-balancer and etcd are not
+ supported on LXD at this time.
+ - Destroying the the easyrsa charm will result in loss of public key
+ infrastructure (PKI).
 
-# Kubernetes information
+## Kubernetes details
 
-- [Kubernetes homepage](http://kubernetes.io/)
-- [Kubernetes documentation](http://kubernetes.io/docs/)
-- [Kubernetes github](https://github.com/kubernetes/kubernetes/)
-- [Getting started with kubernetes and Juju](http://kubernetes.io/docs/getting-started-guides/juju/)
+- [Kubernetes User Guide](http://kubernetes.io/docs/user-guide/)
+- [The Canonical Distribution of Kubernetes ](https://jujucharms.com/canonical-kubernetes/bundle/)
+- [Bundle Source](https://github.com/juju-solutions/bundle-kubernetes-core)
+- [Bug tracker](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues)

--- a/README.md
+++ b/README.md
@@ -373,11 +373,11 @@ for other machine constraints that might be useful for the kubernetes-worker uni
 
 ### Scaling Etcd
 
-Etcd is used as a key-value store for the Kubernetes cluster. For reliability
-the bundle defaults to three instances in this cluster.
+Etcd is used as a key-value store for the Kubernetes cluster. The bundle
+defaults to one instance in this cluster.
 
-For more scalability, we recommend between 3 and 9 etcd nodes. If you want to
-add more nodes:
+For reliability and more scalability, we recommend between 3 and 9 etcd nodes.
+If you want to add more nodes:
 
 ```
 juju add-unit etcd

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10,9 +10,9 @@ machines:
   1:
   2:
   3:
-applications:
+services:
   "kubernetes-master":
-    charm: "cs:~containers/kubernetes-master-3"
+    charm: "cs:~containers/kubernetes-master-4"
     num_units: 1
     to:
       - 1
@@ -42,7 +42,7 @@ applications:
       "gui-x": "450"
       "gui-y": "550"
   "kubernetes-worker":
-    charm: "cs:~containers/kubernetes-worker-3"
+    charm: "cs:~containers/kubernetes-worker-4"
     num_units: 1
     to:
       - 2
@@ -52,7 +52,7 @@ applications:
       "gui-y": "850"
 #    constraints: cpu-cores=4 mem=15G root-disk=30G
   etcd:
-    charm: "cs:~containers/etcd-13"
+    charm: "cs:~containers/etcd-14"
     num_units: 1
     to:
       - 3

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9,7 +9,6 @@ machines:
   0:
   1:
   2:
-  3:
 services:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master-4"
@@ -55,7 +54,7 @@ services:
     charm: "cs:~containers/etcd-14"
     num_units: 1
     to:
-      - 3
+      - 0
     annotations:
       "gui-x": "800"
       "gui-y": "550"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,21 +1,85 @@
+# The machine constraints for each service in this bundle
+# have been commented out so you don't run into quota
+# problems on public clouds. Modify and uncomment the
+# constraints: lines for each service to reflect your
+# deployment before moving to production.
+#
 series: xenial
-services:
-  kubernetes:
-    charm: cs:xenial/kubernetes-8
-    options:
-      version: v1.3.4
+machines:
+  0:
+  1:
+  2:
+  3:
+applications:
+  "kubernetes-master":
+    charm: "cs:~containers/kubernetes-master-3"
+    num_units: 1
+    to:
+      - 1
+    annotations:
+      "gui-x": "800"
+      "gui-y": "850"
+  flannel:
+    charm: "cs:~containers/flannel-4"
+    annotations:
+      "gui-x": "450"
+      "gui-y": "750"
+  "kubeapi-load-balancer":
+    charm: "cs:~containers/kubeapi-load-balancer-2"
+    num_units: 1
+    to:
+      - 0
     expose: true
-    num_units: 2
     annotations:
-      gui-x: '0'
-      gui-y: '0'
+      "gui-x": "450"
+      "gui-y": "250"
+  easyrsa:
+    charm: "cs:~containers/easyrsa-2"
+    num_units: 1
+    to:
+      - lxd:0
+    annotations:
+      "gui-x": "450"
+      "gui-y": "550"
+  "kubernetes-worker":
+    charm: "cs:~containers/kubernetes-worker-3"
+    num_units: 1
+    to:
+      - 2
+    expose: true
+    annotations:
+      "gui-x": "100"
+      "gui-y": "850"
+#    constraints: cpu-cores=4 mem=15G root-disk=30G
   etcd:
-    charm: cs:xenial/etcd-8
-    num_units: 3
+    charm: "cs:~containers/etcd-13"
+    num_units: 1
+    to:
+      - 3
     annotations:
-      gui-x: '300'
-      gui-y: '0'
+      "gui-x": "800"
+      "gui-y": "550"
+#    constraints: cpu-cores=2 root-disk=12G
 relations:
-- - kubernetes:etcd
-  - etcd:db
-
+  - - "kubernetes-master:kube-api-endpoint"
+    - "kubeapi-load-balancer:apiserver"
+  - - "kubernetes-master:loadbalancer"
+    - "kubeapi-load-balancer:loadbalancer"
+  - - "kubernetes-master:cluster-dns"
+    - "kubernetes-worker:kube-dns"
+  - - "kubernetes-master:certificates"
+    - "easyrsa:client"
+  - - "kubernetes-master:etcd"
+    - "etcd:db"
+  - - "kubernetes-master:sdn-plugin"
+    - "flannel:host"
+  - - "kubernetes-worker:certificates"
+    - "easyrsa:client"
+  - - "kubernetes-worker:sdn-plugin"
+    - "flannel:host"
+  - - "kubernetes-worker:kube-api-endpoint"
+    - "kubeapi-load-balancer:website"
+  - - "flannel:etcd"
+    - "etcd:db"
+  - - "kubeapi-load-balancer:certificates"
+    - "easyrsa:client"


### PR DESCRIPTION
Work for https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/70

This pulls in additional functionality from canonical-kubernetes (flannel, ingress, etc) while trying to maintain a low machine footprint.

This includes an updated README as well, [see here](https://github.com/juju-solutions/bundle-kubernetes-core/tree/gkk/converged).

@chuckbutler @mbruzek @wwwtyro @marcoceppi 
