### PR TITLE
remove kubeapi-load-balancer, move kubernetes-master to machine 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This is a minimal Kubernetes cluster comprised of the following components and f
      - Two node Kubernetes cluster with one master node and one worker node.
      - TLS used for communication between nodes for security.
      - Flannel Software Defined Network (SDN) plugin
-     - A load balancer for HA kubernetes-master (Experimental)
      - Optional Ingress Controller and Dashboard (on worker/master respectively)
 - EasyRSA
      - Performs the role of a certificate authority serving self signed certificates
@@ -64,13 +63,12 @@ juju deploy kubernetes-core
 proxy configuration options as described in the Proxy configuration section
 above.
 
-This bundle exposes the kubeapi-load-balancer and kubernetes-worker charms by
-default. This means those charms are accessible through their public addresses.
+This bundle exposes the kubernetes-worker charm by default. This means that
+it is accessible through its public address.
 
-If you would like to remove external access, unexpose the applications:
+If you would like to remove external access, unexpose the application:
 
 ```
-juju unexpose kubeapi-load-balancer
 juju unexpose kubernetes-worker
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This is a minimal Kubernetes cluster comprised of the following components and features:
 
 - Kubernetes (automated deployment, operations, and scaling)
-     - Two node Kubernetes cluster with one master node and one worker node.
+     - Three node Kubernetes cluster with one master node and two worker nodes.
      - TLS used for communication between nodes for security.
      - Flannel Software Defined Network (SDN) plugin
      - Optional Ingress Controller and Dashboard (on worker/master respectively)

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8,6 +8,7 @@ series: xenial
 machines:
   0:
   1:
+  2:
 services:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master-4"
@@ -32,9 +33,10 @@ services:
       "gui-y": "550"
   "kubernetes-worker":
     charm: "cs:~containers/kubernetes-worker-5"
-    num_units: 1
+    num_units: 2
     to:
       - 1
+      - 2
     expose: true
     annotations:
       "gui-x": "100"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8,13 +8,12 @@ series: xenial
 machines:
   0:
   1:
-  2:
 services:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master-4"
     num_units: 1
     to:
-      - 1
+      - 0
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -23,15 +22,6 @@ services:
     annotations:
       "gui-x": "450"
       "gui-y": "750"
-  "kubeapi-load-balancer":
-    charm: "cs:~containers/kubeapi-load-balancer-3"
-    num_units: 1
-    to:
-      - 0
-    expose: true
-    annotations:
-      "gui-x": "450"
-      "gui-y": "250"
   easyrsa:
     charm: "cs:~containers/easyrsa-2"
     num_units: 1
@@ -44,7 +34,7 @@ services:
     charm: "cs:~containers/kubernetes-worker-5"
     num_units: 1
     to:
-      - 2
+      - 1
     expose: true
     annotations:
       "gui-x": "100"
@@ -61,9 +51,7 @@ services:
 #    constraints: cpu-cores=2 root-disk=12G
 relations:
   - - "kubernetes-master:kube-api-endpoint"
-    - "kubeapi-load-balancer:apiserver"
-  - - "kubernetes-master:loadbalancer"
-    - "kubeapi-load-balancer:loadbalancer"
+    - "kubernetes-worker:kube-api-endpoint"
   - - "kubernetes-master:cluster-dns"
     - "kubernetes-worker:kube-dns"
   - - "kubernetes-master:certificates"
@@ -76,9 +64,5 @@ relations:
     - "easyrsa:client"
   - - "kubernetes-worker:sdn-plugin"
     - "flannel:host"
-  - - "kubernetes-worker:kube-api-endpoint"
-    - "kubeapi-load-balancer:website"
   - - "flannel:etcd"
     - "etcd:db"
-  - - "kubeapi-load-balancer:certificates"
-    - "easyrsa:client"


### PR DESCRIPTION
Follow-up to #25 and https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/70:
- Removed kubeapi-load-balancer
- Moved kubernetes-master to machine 0 (shared with etcd)
- Updated README to reflect the removal of kubeapi-load-balancer

This brings us down to 2 machines total. Early testing shows no obvious problems - microbot came up for me, at least.

Thanks @marcoceppi and @chuckbutler for suggesting this!

Cc @mbruzek @wwwtyro 
