### PR TITLE
Bump etcd to current edge channel release for testing

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -39,7 +39,7 @@ services:
       "gui-y": "850"
 #    constraints: cpu-cores=4 mem=15G root-disk=30G
   etcd:
-    charm: "cs:~containers/etcd-19"
+    charm: "cs:~containers/etcd-20"
     num_units: 1
     to:
       - "0"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -39,7 +39,7 @@ services:
       "gui-y": "850"
 #    constraints: cpu-cores=4 mem=15G root-disk=30G
   etcd:
-    charm: "cs:~containers/etcd-17"
+    charm: "cs:~containers/etcd-19"
     num_units: 1
     to:
       - "0"
@@ -56,6 +56,8 @@ relations:
     - "easyrsa:client"
   - - "kubernetes-master:etcd"
     - "etcd:db"
+  - - "etcd:certificates"
+    - "easyrsa:client"
   - - "kubernetes-master:sdn-plugin"
     - "flannel:host"
   - - "kubernetes-worker:certificates"


### PR DESCRIPTION
This hard-repoints etcd to the version integrating with easyrsa. This is
a slightly more robust and offline-able solution as it integrates with
the CA instead of packing/cloning easyrsa into the etcd charm itself.

This is a non-backwords-compatible change.